### PR TITLE
Add ability to append HTML files

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -116,7 +116,16 @@ function sourceFileToJS (filePath) {
     return fileContents
   } else if (filePath.endsWith('css')) {
     return wrapCSS(escapeSingleQuotes(escapeBackslash(removeLineBreaks(fileContents))));
+  } else if (filePath.endsWith('html')) {
+    return wrapHTML(escapeSingleQuotes(escapeBackslash(removeLineBreaks(fileContents))));
   }
+}
+
+// Wrap a HTML string in executable JavaScript that appends it to `body`
+function wrapHTML (htmlText) {
+  return `var div=document.createElement('div');div.style='position:absolute;top:-999999px;left:-999999px';` + 
+    `div.innerHTML='${htmlText}';` +
+    `document.body.appendChild(div);\n`
 }
 
 // Wrap a JavaScript string in a commented IIFE


### PR DESCRIPTION
Hey there...

I started using fecli a few weeks ago, and have since modified it enough to add my own html instead of doing so through javascript.

Here is my implementation, though not fully tested, is enough to work. It adds the html file to a _hidden_ div. This then allows me in most cases to then grab it and inject it where I need it, if so desired.